### PR TITLE
Should not zoom on mobile phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Idle town</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, user-scalable=no" />
     <link rel="stylesheet" href="/src/resources/index.css">
 </head>
 <body>


### PR DESCRIPTION
This prevents mobile phones zooming in when double tapping too fast